### PR TITLE
Add start script which utilizes cluster service

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,11 @@
 {
-    "dependencies": {
-        "express": "4.17.1",
-        "body-parser": "1.19.0",
-        "mongoose": "5.9.1"
-    }
+  "scripts": {
+    "start": "cservice src/index.js --accessKey lksjdf982734"
+  },
+  "dependencies": {
+    "body-parser": "1.19.0",
+    "cluster-service": "^2.1.3",
+    "express": "4.17.1",
+    "mongoose": "5.9.1"
+  }
 }


### PR DESCRIPTION
Starting the server using the cluster-service module decreases latency significantly and allows
higher throughput. To start the server with clustering, run "npm run start"